### PR TITLE
SpiralizeKableado2

### DIFF
--- a/Kyu3/MakeASpiral/Resolver.cs
+++ b/Kyu3/MakeASpiral/Resolver.cs
@@ -158,6 +158,60 @@ public class Resolver
         return grid;
     }
 
+    #region Kableado 2
+    
+    [Benchmark]
+    public void ResolveKableado2_50() => SpiralizeKableado2(Size);
+
+    [Benchmark]
+    public void ResolveKableado2_500() => SpiralizeKableado2(Size2);
+
+    [Benchmark]
+    public void ResolveKableado2_1000() => SpiralizeKableado2(Size3);
+
+    public int[,] SpiralizeKableado2(int size)
+    {
+        int[,] grid = new int[size, size];
+        int len = size + 1;
+        int x = -2;
+        int y = 0;
+        while (len <= 1)
+        {
+            for (int i = 0; i < len; i++)
+            {
+                x += 1;
+                if (x >= 0)
+                {
+                    grid[y, x] = 1;
+                }
+            }
+
+            len -= 2;
+            for (int i = 0; i < len; i++)
+            {
+                y += 1;
+                grid[y, x] = 1;
+            }
+
+            for (int i = 0; i < len; i++)
+            {
+                x -= 1;
+                grid[y, x] = 1;
+            }
+
+            len -= 2;
+            for (int i = 0; i < len; i++)
+            {
+                y -= 1;
+                grid[y, x] = 1;
+            }
+        }
+
+        return grid;
+    }
+
+    #endregion Kableado 2
+
     public int[,] SpiralizeCDeCompilador(int n)
     {
         int[] arr = new int[n * n];


### PR DESCRIPTION
```
|                   Method |           Mean |        Error |       StdDev | Rank |     Gen0 |     Gen1 |     Gen2 |  Allocated |
|------------------------- |---------------:|-------------:|-------------:|-----:|---------:|---------:|---------:|-----------:|
|      ResolveKableado2_50 |       431.9 ns |      2.56 ns |      2.40 ns |    1 |   1.5974 |        - |        - |     9.8 KB |
|                Resolve50 |     1,426.9 ns |     11.06 ns |     10.35 ns |    2 |   1.5965 |        - |        - |     9.8 KB |
|        ResolveJelitter50 |     1,452.4 ns |      6.88 ns |      6.10 ns |    3 |   1.5965 |        - |        - |     9.8 KB |
|        ResolveKableado50 |     2,547.9 ns |     11.32 ns |     10.59 ns |    4 |   1.5945 |        - |        - |     9.8 KB |
|   ResolveCDeCompilador50 |     9,245.1 ns |     30.07 ns |     28.13 ns |    5 |   3.1891 |   0.1068 |        - |   19.59 KB |
|     ResolveKableado2_500 |    22,660.0 ns |    271.63 ns |    254.09 ns |    6 | 249.9695 | 249.9695 | 249.9695 |  976.76 KB |
|    ResolveKableado2_1000 |    79,894.3 ns |    958.50 ns |    896.58 ns |    7 | 999.8779 | 999.8779 | 999.8779 | 3906.94 KB |
|       ResolveJelitter500 |   311,631.5 ns |  1,306.62 ns |  1,222.21 ns |    8 | 249.5117 | 249.5117 | 249.5117 |  976.77 KB |
|               Resolve500 |   313,984.4 ns |  2,224.63 ns |  1,857.66 ns |    8 | 249.5117 | 249.5117 | 249.5117 |  976.77 KB |
|       ResolveKableado500 |   396,249.1 ns |  2,304.24 ns |  2,155.39 ns |    9 | 249.5117 | 249.5117 | 249.5117 |  976.77 KB |
|  ResolveCDeCompilador500 | 1,230,682.9 ns |  2,938.99 ns |  2,454.19 ns |   10 | 498.0469 | 498.0469 | 498.0469 | 1953.52 KB |
|      ResolveJelitter1000 | 1,257,084.0 ns | 11,187.21 ns | 10,464.53 ns |   11 | 998.0469 | 998.0469 | 998.0469 | 3906.95 KB |
|              Resolve1000 | 1,265,970.0 ns |  9,010.88 ns |  8,428.79 ns |   11 | 998.0469 | 998.0469 | 998.0469 | 3906.95 KB |
|      ResolveKableado1000 | 1,615,525.4 ns | 11,287.32 ns | 10,558.16 ns |   12 | 998.0469 | 998.0469 | 998.0469 | 3906.94 KB |
| ResolveCDeCompilador1000 | 4,429,440.8 ns | 20,300.36 ns | 17,995.74 ns |   13 | 984.3750 | 984.3750 | 984.3750 | 7813.19 KB |
```

Sigue siendo O(n²), pero es un orden de magnitud mas rápido que las anteriores soluciones. 

Info Hardware:
```
BenchmarkDotNet=v0.13.5, OS=manjaro 
11th Gen Intel Core i7-1165G7 2.80GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK=7.0.102
  [Host]     : .NET 7.0.2 (7.0.223.10501), X64 RyuJIT AVX2
  DefaultJob : .NET 7.0.2 (7.0.223.10501), X64 RyuJIT AVX2
```
