### PR TITLE
Fix SpiralizeKableado2 and add tests

### DIFF
--- a/Dnj.Colab.Training.Codewars.sln
+++ b/Dnj.Colab.Training.Codewars.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MakeASpiral", "Kyu3\MakeASp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SnailSort", "Kyu4\SnailSort\SnailSort.csproj", "{73D36217-28CB-41EA-ADC2-27F1DA183CD0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MakeASpiral.Test", "MakeASpiral.Test\MakeASpiral.Test.csproj", "{84D7F972-C87D-4DD1-856C-9253384BFC94}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{73D36217-28CB-41EA-ADC2-27F1DA183CD0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{73D36217-28CB-41EA-ADC2-27F1DA183CD0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{73D36217-28CB-41EA-ADC2-27F1DA183CD0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{84D7F972-C87D-4DD1-856C-9253384BFC94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84D7F972-C87D-4DD1-856C-9253384BFC94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84D7F972-C87D-4DD1-856C-9253384BFC94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84D7F972-C87D-4DD1-856C-9253384BFC94}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Kyu3/MakeASpiral/Resolver.cs
+++ b/Kyu3/MakeASpiral/Resolver.cs
@@ -175,7 +175,7 @@ public class Resolver
         int len = size + 1;
         int x = -2;
         int y = 0;
-        while (len <= 1)
+        while (len > 1)
         {
             for (int i = 0; i < len; i++)
             {

--- a/Kyu3/MakeASpiral/Resolver.cs
+++ b/Kyu3/MakeASpiral/Resolver.cs
@@ -89,7 +89,7 @@ public class Resolver
         //SpiralizeCDeCompilador(Size);
         SpiralizeCDeCompilador(Size3);
 
-    private void SpiralizeJelitter(int[,] arr, int x)
+    public void SpiralizeJelitter(int[,] arr, int x)
     {
         int arrLength = arr.GetLength(0);
         if ((x > Math.Ceiling((float)arrLength / 2) - 1))
@@ -279,7 +279,7 @@ public class Resolver
         return result;
     }
 
-    private void PaintIteration(int[,] res, int index, int size)
+    public void PaintIteration(int[,] res, int index, int size)
     {
         if (index >= size)
         {

--- a/MakeASpiral.Test/MakeASpiral.Test.csproj
+++ b/MakeASpiral.Test/MakeASpiral.Test.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Kyu3\MakeASpiral\MakeASpiral.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/MakeASpiral.Test/ResolverTest.cs
+++ b/MakeASpiral.Test/ResolverTest.cs
@@ -1,0 +1,119 @@
+namespace MakeASpiral.Test;
+
+public class ResolverTest
+{
+    private readonly int[,] _expectedTest05 = {
+        {1, 1, 1, 1, 1},
+        {0, 0, 0, 0, 1},
+        {1, 1, 1, 0, 1},
+        {1, 0, 0, 0, 1},
+        {1, 1, 1, 1, 1}
+    };
+
+    private readonly int[,] _expectedTest8 = {
+        {1, 1, 1, 1, 1, 1, 1, 1},
+        {0, 0, 0, 0, 0, 0, 0, 1},
+        {1, 1, 1, 1, 1, 1, 0, 1},
+        {1, 0, 0, 0, 0, 1, 0, 1},
+        {1, 0, 1, 0, 0, 1, 0, 1},
+        {1, 0, 1, 1, 1, 1, 0, 1},
+        {1, 0, 0, 0, 0, 0, 0, 1},
+        {1, 1, 1, 1, 1, 1, 1, 1},
+    };
+    
+    [Fact]
+    public void Spiralize_Test05()
+    {
+        const int input = 5;
+
+        int[,] actual = new int[input, input];
+        new Resolver().PaintIteration(actual, 0, input);
+        Assert.Equal(_expectedTest05, actual);
+    }
+    
+    [Fact]
+    public void Spiralize_Test08()
+    {
+        const int input = 8;
+        
+        int[,] actual = new int[input, input];
+        new Resolver().PaintIteration(actual, 0, input);
+        Assert.Equal(_expectedTest8, actual);
+    }
+
+    [Fact]
+    public void SpiralizeJelitter_Test05()
+    {
+        const int input = 5;
+
+        int[,] actual = new int[input, input];
+        new Resolver().SpiralizeJelitter(actual, 0);
+        Assert.Equal(_expectedTest05, actual);
+    }
+    
+    [Fact]
+    public void SpiralizeJelitter_Test08()
+    {
+        const int input = 8;
+        
+        int[,] actual = new int[input, input];
+        new Resolver().SpiralizeJelitter(actual, 0);
+        Assert.Equal(_expectedTest8, actual);
+    }
+
+    [Fact]
+    public void SpiralizeKableado_Test05()
+    {
+        const int input = 5;
+
+        int[,] actual = new Resolver().SpiralizeKableado(input);
+        Assert.Equal(_expectedTest05, actual);
+    }
+    
+    [Fact]
+    public void SpiralizeKableado_Test08()
+    {
+        const int input = 8;
+        
+        int[,] actual = new Resolver().SpiralizeKableado(input);
+        Assert.Equal(_expectedTest8, actual);
+    }
+    
+    [Fact]
+    public void SpiralizeKableado2_Test05()
+    {
+        const int input = 5;
+
+        int[,] actual = new Resolver().SpiralizeKableado2(input);
+        Assert.Equal(_expectedTest05, actual);
+    }
+    
+    [Fact]
+    public void SpiralizeKableado2_Test08()
+    {
+        const int input = 8;
+        
+        int[,] actual = new Resolver().SpiralizeKableado2(input);
+        Assert.Equal(_expectedTest8, actual);
+    }
+    
+    
+    [Fact]
+    public void SpiralizeCDeCompilador_Test05()
+    {
+        const int input = 5;
+
+        int[,] actual = new Resolver().SpiralizeCDeCompilador(input);
+        Assert.Equal(_expectedTest05, actual);
+    }
+    
+    [Fact]
+    public void SpiralizeCDeCompilador_Test08()
+    {
+        const int input = 8;
+        
+        int[,] actual = new Resolver().SpiralizeCDeCompilador(input);
+        Assert.Equal(_expectedTest8, actual);
+    }
+
+}

--- a/MakeASpiral.Test/Usings.cs
+++ b/MakeASpiral.Test/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;


### PR DESCRIPTION
### Fix SpiralizeKableado2 and add tests

La mejora de rendimiento era un error, ya hemos vuelto a la normalidad. Para evitar otros slips, he añadido tests y los he aplicado a todas las implementaciones... pero todas no pasan.